### PR TITLE
Update LBS API calls

### DIFF
--- a/go-app.js
+++ b/go-app.js
@@ -68,8 +68,8 @@ go.app = function() {
                 response: {
                     template_type: "SMS",
                     to_addr: contact.msisdn,
-                    template: "Your nearest clinic is %result%. Thanks for " +
-                              "using Clinic Finder"
+                    template: "Your nearest clinic is {{ results }}. Thanks " +
+                              "for using Clinic Finder"
                 },
                 location: location
             };
@@ -88,31 +88,18 @@ go.app = function() {
 
         self.manual_locate = function(contact) {
             return self.http
-                .post(self.req_location_url, {
-                    data: self.make_location_data(contact)
-                })
-                .then(function(response) {
-                    return self.http
-                        .post(self.req_lookup_url, {
-                            data: self.make_lookup_data(contact,
-                                self.req_location_url + response.data.id + '/')
-                        });
+                .post(self.req_lookup_url, {
+                    data: self.make_lookup_data(contact,
+                        self.make_location_data(contact))
                 });
         };
 
         self.lbs_locate = function(contact) {
             return self.http
-                .post(self.req_lookup_url, {
-                    data: self.make_lookup_data(contact, null)
-                })
-                .then(function(response) {
-                    return self.http
-                        .post(self.lbsrequest_url, {
-                            data: self.make_lbs_data(contact,
-                                self.req_lookup_url + response.data.id + '/')
-                        });
+                .post(self.lbsrequest_url, {
+                    data: self.make_lbs_data(contact,
+                        self.make_lookup_data(contact, null))
                 });
-
         };
 
 

--- a/go-app.js
+++ b/go-app.js
@@ -29,7 +29,21 @@ go.app = function() {
                 });
         };
 
-        self.locate = function(contact) {
+        self.make_clinic_search_params = function() {
+            var clinic_type_requested = self.im.user.answers.state_clinic_type;
+            var search_data = {};
+
+            if (clinic_type_requested === "nearest") {
+                self.im.config.clinic_types.forEach(function(clinic_type) {
+                    search_data[clinic_type] = "true";
+                });
+            } else {
+                search_data[clinic_type_requested] = "true";
+            }
+            return search_data;
+        };
+
+        self.manual_locate = function(contact) {
             var location_url = self.im.config.api_url + 'requestlocation/';
             var lookup_url = self.im.config.api_url + 'requestlookup/';
 
@@ -44,15 +58,14 @@ go.app = function() {
             };
 
             var lookup_data = {
-                search: {
-                    mmc: ((self.im.user.answers.state_clinic_type === 'mmc') ? "true" : "false")
-                },
+                search: self.make_clinic_search_params(),
                 response: {
                     template_type: "SMS",
                     to_addr: contact.msisdn,
-                    template: "Your nearest clinic is %result%. Thanks for using Clinic Finder"
+                    template: "Your nearest clinic is %result%. Thanks for " +
+                              "using Clinic Finder"
                 },
-                location: "http://127.0.0.1:8000/clinicfinder/requestlocation/"
+                location: location_url
             };
 
             return self.http
@@ -66,6 +79,42 @@ go.app = function() {
                             data: lookup_data
                         });
                 });
+        };
+
+        self.lbs_locate = function(contact) {
+            var lookup_url = self.im.config.api_url + 'requestlookup/';
+            var lbs_url = self.im.config.api_url + 'lbsrequest/';
+
+            lbs_data = {
+                search: {
+                    msisdn: contact.msisdn.replace(/[^0-9]/g, "")  // remove '+'
+                },
+                pointofinterest: lookup_url
+            };
+
+            var lookup_data = {
+                search: self.make_clinic_search_params(),
+                response: {
+                    template_type: "SMS",
+                    to_addr: contact.msisdn,
+                    template: "Your nearest clinic is %result%. Thanks for " +
+                              "using Clinic Finder"
+                },
+                location: null
+            };
+
+            return self.http
+                .post(lookup_url, {
+                    data: lookup_data
+                })
+                .then(function(response) {
+                    lbs_data.pointofinterest += (response.data.id + '/');
+                    return self.http
+                        .post(lbs_url, {
+                            data: lbs_data
+                        });
+                });
+
         };
 
 
@@ -146,7 +195,7 @@ go.app = function() {
 
                 next: function(choice) {
                     switch (choice.value) {
-                        case 'locate': return 'state_health_services';  // pending - change to state_locate_clinic
+                        case 'locate': return 'state_lbs_locate';
                         case 'no_locate': return 'state_reprompt_permission';
                     }
                 }
@@ -168,12 +217,20 @@ go.app = function() {
 
                 next: function(choice) {
                     switch (choice.value) {
-                        case 'consent': return 'state_health_services';  // pending - change to state_locate_clinic
+                        case 'consent': return 'state_lbs_locate';
                         case 'suburb': return 'state_suburb';
                         case 'quit': return 'state_quit';
                     }
                 }
             });
+        });
+
+        self.states.add('state_lbs_locate', function(name) {
+            return self
+                .lbs_locate(self.contact)
+                .then(function() {
+                    return self.states.create('state_health_services');
+                });
         });
 
         self.states.add('state_suburb', function(name) {
@@ -205,7 +262,7 @@ go.app = function() {
                 })
                 .then(function() {
                     return self
-                        .locate(self.contact)
+                        .manual_locate(self.contact)
                         .then(function() {
                             return self.states.create('state_health_services');
                         });

--- a/src/app.js
+++ b/src/app.js
@@ -13,6 +13,11 @@ go.app = function() {
         var $ = self.$;
 
         self.init = function() {
+            // Configure URLs
+            self.req_location_url = self.im.config.api_url + 'requestlocation/';
+            self.req_lookup_url = self.im.config.api_url + 'requestlookup/';
+            self.lbsrequest_url = self.im.config.api_url + 'lbsrequest/';
+
             self.http = new JsonApi(self.im);
 
             return self.im.contacts
@@ -21,6 +26,7 @@ go.app = function() {
                    self.contact = user_contact;
                 });
         };
+
 
         self.make_clinic_search_params = function() {
             var clinic_type_requested = self.im.user.answers.state_clinic_type;
@@ -36,10 +42,7 @@ go.app = function() {
             return search_data;
         };
 
-        self.manual_locate = function(contact) {
-            var location_url = self.im.config.api_url + 'requestlocation/';
-            var lookup_url = self.im.config.api_url + 'requestlookup/';
-
+        self.make_location_data = function(contact) {
             var location_data = {
                 point: {
                     type: "Point",
@@ -49,7 +52,10 @@ go.app = function() {
                     ]
                 }
             };
+            return location_data;
+        };
 
+        self.make_lookup_data = function(contact, location) {
             var lookup_data = {
                 search: self.make_clinic_search_params(),
                 response: {
@@ -58,53 +64,45 @@ go.app = function() {
                     template: "Your nearest clinic is %result%. Thanks for " +
                               "using Clinic Finder"
                 },
-                location: location_url
+                location: location
             };
+            return lookup_data;
+        };
 
+        self.make_lbs_data = function(contact, pointofinterest) {
+            var lbs_data = {
+                search: {
+                    msisdn: contact.msisdn.replace(/[^0-9]/g, "")  // remove '+'
+                },
+                pointofinterest: pointofinterest
+            };
+            return lbs_data;
+        };
+
+        self.manual_locate = function(contact) {
             return self.http
-                .post(location_url, {
-                    data: location_data
+                .post(self.req_location_url, {
+                    data: self.make_location_data(contact)
                 })
                 .then(function(response) {
-                    lookup_data.location += (response.data.id + '/');
                     return self.http
-                        .post(lookup_url, {
-                            data: lookup_data
+                        .post(self.req_lookup_url, {
+                            data: self.make_lookup_data(contact,
+                                self.req_location_url + response.data.id + '/')
                         });
                 });
         };
 
         self.lbs_locate = function(contact) {
-            var lookup_url = self.im.config.api_url + 'requestlookup/';
-            var lbs_url = self.im.config.api_url + 'lbsrequest/';
-
-            lbs_data = {
-                search: {
-                    msisdn: contact.msisdn.replace(/[^0-9]/g, "")  // remove '+'
-                },
-                pointofinterest: lookup_url
-            };
-
-            var lookup_data = {
-                search: self.make_clinic_search_params(),
-                response: {
-                    template_type: "SMS",
-                    to_addr: contact.msisdn,
-                    template: "Your nearest clinic is %result%. Thanks for " +
-                              "using Clinic Finder"
-                },
-                location: null
-            };
-
             return self.http
-                .post(lookup_url, {
-                    data: lookup_data
+                .post(self.req_lookup_url, {
+                    data: self.make_lookup_data(contact, null)
                 })
                 .then(function(response) {
-                    lbs_data.pointofinterest += (response.data.id + '/');
                     return self.http
-                        .post(lbs_url, {
-                            data: lbs_data
+                        .post(self.lbsrequest_url, {
+                            data: self.make_lbs_data(contact,
+                                self.req_lookup_url + response.data.id + '/')
                         });
                 });
 

--- a/src/app.js
+++ b/src/app.js
@@ -61,8 +61,8 @@ go.app = function() {
                 response: {
                     template_type: "SMS",
                     to_addr: contact.msisdn,
-                    template: "Your nearest clinic is %result%. Thanks for " +
-                              "using Clinic Finder"
+                    template: "Your nearest clinic is {{ results }}. Thanks " +
+                              "for using Clinic Finder"
                 },
                 location: location
             };
@@ -81,31 +81,18 @@ go.app = function() {
 
         self.manual_locate = function(contact) {
             return self.http
-                .post(self.req_location_url, {
-                    data: self.make_location_data(contact)
-                })
-                .then(function(response) {
-                    return self.http
-                        .post(self.req_lookup_url, {
-                            data: self.make_lookup_data(contact,
-                                self.req_location_url + response.data.id + '/')
-                        });
+                .post(self.req_lookup_url, {
+                    data: self.make_lookup_data(contact,
+                        self.make_location_data(contact))
                 });
         };
 
         self.lbs_locate = function(contact) {
             return self.http
-                .post(self.req_lookup_url, {
-                    data: self.make_lookup_data(contact, null)
-                })
-                .then(function(response) {
-                    return self.http
-                        .post(self.lbsrequest_url, {
-                            data: self.make_lbs_data(contact,
-                                self.req_lookup_url + response.data.id + '/')
-                        });
+                .post(self.lbsrequest_url, {
+                    data: self.make_lbs_data(contact,
+                        self.make_lookup_data(contact, null))
                 });
-
         };
 
 

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -67,7 +67,8 @@ describe("app", function() {
                     welcome_enabled: false,
                     sms_number: '555',
                     lbs_providers: ['VODACOM', 'MTN'],
-                    api_url: 'http://127.0.0.1:8000/clinicfinder/'
+                    api_url: 'http://127.0.0.1:8000/clinicfinder/',
+                    clinic_types: ['mmc', 'hct']
                 })
                 .setup(function(api) {
                     api.contacts.add({

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -3,52 +3,6 @@ module.exports = function() {
       {
          "request": {
             "method": "POST",
-            "url": "http://127.0.0.1:8000/clinicfinder/requestlocation/",
-            "data": {
-               "point": {
-                  "type": "Point",
-                  "coordinates": ["3.3", "3.33"]
-               }
-            }
-         },
-         "response": {
-            "data": {
-               "id": 1,
-               "point": {
-                  "type": "Point",
-                  "coordinates": ["3.3", "3.33"]
-               }
-            }
-         }
-      },
-
-
-      {
-         "request": {
-            "method": "POST",
-            "url": "http://127.0.0.1:8000/clinicfinder/requestlocation/",
-            "data": {
-               "point": {
-                  "type": "Point",
-                  "coordinates": ["3.1415", "2.7182"]
-               }
-            }
-         },
-         "response": {
-            "data": {
-               "id": 2,
-               "point": {
-                  "type": "Point",
-                  "coordinates": ["3.1415", "2.7182"]
-               }
-            }
-         }
-      },
-
-
-      {
-         "request": {
-            "method": "POST",
             "url": "http://127.0.0.1:8000/clinicfinder/requestlookup/",
             "data": {
                "search": {
@@ -57,9 +11,14 @@ module.exports = function() {
                "response": {
                   "template_type": "SMS",
                   "to_addr": "+082111",
-                  "template": "Your nearest clinic is %result%. Thanks for using Clinic Finder"
+                  "template": "Your nearest clinic is {{ results }}. Thanks for using Clinic Finder"
                },
-               "location": "http://127.0.0.1:8000/clinicfinder/requestlocation/1/"
+               "location": {
+                  "point": {
+                     "type": "Point",
+                     "coordinates": ["3.3", "3.33"]
+                  }
+               }
             }
          },
          "response": {
@@ -72,11 +31,15 @@ module.exports = function() {
                "response": {
                   "template_type": "SMS",
                   "to_addr": "+082111",
-                  "template": "Your nearest clinic is %result%. Thanks for using Clinic Finder"
+                  "template": "Your nearest clinic is {{ results }}. Thanks for using Clinic Finder"
                },
-               "location": "http://127.0.0.1:8000/clinicfinder/requestlocation/1/",
-               "created_at": "2015-01-14T10:40:16.892Z",
-               "updated_at": "2015-01-14T10:40:16.892Z"
+               "location": {
+                  "id": 1,
+                  "point": {
+                     "type": "Point",
+                     "coordinates": ["3.3", "3.33"]
+                  }
+               }
             }
          }
       },
@@ -93,9 +56,14 @@ module.exports = function() {
                "response": {
                   "template_type": "SMS",
                   "to_addr": "+082111",
-                  "template": "Your nearest clinic is %result%. Thanks for using Clinic Finder"
+                  "template": "Your nearest clinic is {{ results }}. Thanks for using Clinic Finder"
                },
-               "location": "http://127.0.0.1:8000/clinicfinder/requestlocation/2/"
+               "location": {
+                  "point": {
+                     "type": "Point",
+                     "coordinates": ["3.1415", "2.7182"]
+                  }
+               }
             }
          },
          "response": {
@@ -108,49 +76,15 @@ module.exports = function() {
                "response": {
                   "template_type": "SMS",
                   "to_addr": "+082111",
-                  "template": "Your nearest clinic is %result%. Thanks for using Clinic Finder"
+                  "template": "Your nearest clinic is {{ results }}. Thanks for using Clinic Finder"
                },
-               "location": "http://127.0.0.1:8000/clinicfinder/requestlocation/2/",
-               "created_at": "2015-01-14T10:40:16.892Z",
-               "updated_at": "2015-01-14T10:40:16.892Z"
-            }
-         }
-      },
-
-
-      {
-         "request": {
-            "method": "POST",
-            "url": "http://127.0.0.1:8000/clinicfinder/requestlookup/",
-            "data": {
-               "search": {
-                  "mmc": "true",
-                  "hct": "true"
-               },
-               "response": {
-                  "template_type": "SMS",
-                  "to_addr": "+082111",
-                  "template": "Your nearest clinic is %result%. Thanks for using Clinic Finder"
-               },
-               "location": null
-            }
-         },
-         "response": {
-            "data": {
-               "id": 3,
-               "url": "http://127.0.0.1:8000/clinicfinder/requestlookup/3",
-               "search": {
-                  "mmc": "true",
-                  "hct": "true"
-               },
-               "response": {
-                  "template_type": "SMS",
-                  "to_addr": "+082111",
-                  "template": "Your nearest clinic is %result%. Thanks for using Clinic Finder"
-               },
-               "location": null  ,
-               "created_at": "2015-01-14T10:40:16.892Z",
-               "updated_at": "2015-01-14T10:40:16.892Z"
+               "location": {
+                  "id": 2,
+                  "point": {
+                     "type": "Point",
+                     "coordinates": ["3.1415", "2.7182"]
+                  }
+               }
             }
          }
       },
@@ -164,19 +98,40 @@ module.exports = function() {
                "search": {
                   "msisdn": "082111"
                },
-               "pointofinterest": "http://127.0.0.1:8000/clinicfinder/requestlookup/3/"
+               "pointofinterest": {
+                  "search": {
+                     "mmc": "true",
+                     "hct": "true"
+                  },
+                  "response": {
+                     "template_type": "SMS",
+                     "to_addr": "+082111",
+                     "template": "Your nearest clinic is {{ results }}. Thanks for using Clinic Finder"
+                  },
+                  "location": null
+               }
             }
          },
          "response": {
             "data": {
                "id": 1,
-               "url": "http://127.0.0.1:8000/clinicfinder/lbsrequest/",
+               "url": "http://127.0.0.1:8000/clinicfinder/lbsrequest/1/",
                "search": {
                   "msisdn": "082111"
                },
-               "pointofinterest": "http://127.0.0.1:8000/clinicfinder/requestlookup/3/",
-               "created_at": "2015-01-14T10:40:16.892Z",
-               "updated_at": "2015-01-14T10:40:16.892Z"
+               "pointofinterest": {
+                  "id": 3,
+                  "search": {
+                     "mmc": "true",
+                     "hct": "true"
+                  },
+                  "response": {
+                     "template_type": "SMS",
+                     "to_addr": "+082111",
+                     "template": "Your nearest clinic is {{ results }}. Thanks for using Clinic Finder"
+                  },
+                  "location": null
+               }
             }
          }
       }

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -64,6 +64,7 @@ module.exports = function() {
          },
          "response": {
             "data": {
+               "id": 1,
                "url": "http://127.0.0.1:8000/clinicfinder/requestlookup/1/",
                "search": {
                   "mmc": "true"
@@ -99,6 +100,7 @@ module.exports = function() {
          },
          "response": {
             "data": {
+               "id": 2,
                "url": "http://127.0.0.1:8000/clinicfinder/requestlookup/2/",
                "search": {
                   "mmc": "true"
@@ -113,6 +115,71 @@ module.exports = function() {
                "updated_at": "2015-01-14T10:40:16.892Z"
             }
          }
+      },
+
+
+      {
+         "request": {
+            "method": "POST",
+            "url": "http://127.0.0.1:8000/clinicfinder/requestlookup/",
+            "data": {
+               "search": {
+                  "mmc": "true",
+                  "hct": "true"
+               },
+               "response": {
+                  "template_type": "SMS",
+                  "to_addr": "+082111",
+                  "template": "Your nearest clinic is %result%. Thanks for using Clinic Finder"
+               },
+               "location": null
+            }
+         },
+         "response": {
+            "data": {
+               "id": 3,
+               "url": "http://127.0.0.1:8000/clinicfinder/requestlookup/3",
+               "search": {
+                  "mmc": "true",
+                  "hct": "true"
+               },
+               "response": {
+                  "template_type": "SMS",
+                  "to_addr": "+082111",
+                  "template": "Your nearest clinic is %result%. Thanks for using Clinic Finder"
+               },
+               "location": null  ,
+               "created_at": "2015-01-14T10:40:16.892Z",
+               "updated_at": "2015-01-14T10:40:16.892Z"
+            }
+         }
+      },
+
+
+      {
+         "request": {
+            "method": "POST",
+            "url": "http://127.0.0.1:8000/clinicfinder/lbsrequest/",
+            "data": {
+               "search": {
+                  "msisdn": "082111"
+               },
+               "pointofinterest": "http://127.0.0.1:8000/clinicfinder/requestlookup/3/"
+            }
+         },
+         "response": {
+            "data": {
+               "id": 1,
+               "url": "http://127.0.0.1:8000/clinicfinder/lbsrequest/",
+               "search": {
+                  "msisdn": "082111"
+               },
+               "pointofinterest": "http://127.0.0.1:8000/clinicfinder/requestlookup/3/",
+               "created_at": "2015-01-14T10:40:16.892Z",
+               "updated_at": "2015-01-14T10:40:16.892Z"
+            }
+         }
       }
+
    ];
 };


### PR DESCRIPTION
The flows are as follows:
- MTN and Vodacom: log a request to `requestlookup` with the search and response template --> log a request to `lbsrequest` with the requestlookup data
- All others: locate with LocationState --> log coordinates to `requestlocation` --> log a request to `requestlookup` with the search and response template and location

The `search` format is (values are strings):

```
{
   "mmc": "true"
}
```

The response format is (values are strings):

```
{
    "type": "SMS",
    "to_addr": "27123",
    "template": "Your ClinicFinder results are: {{ results }}. Thank you for using the service."
}
```

---

The `requestlocation` call is as follows:

```
{
    "point": {
        "type": "Point",
            "coordinates": [x, y]
    }
}
```

---

The `requestlookup` call is as follows:

```
{
    "search": search,
    "response": response,
   "location": null or requestlocation
}
```

---

The `lbsrequest` call is as follows:

`{
    "search": {
        "msisdn": "27123"
   },
  "pointofinterest": requestlookup
}`

Note: msisdn must be for MTN or VodaCom, permission must be given, leading `+` should be stripped out.
