### PR TITLE
Make lat and long floats

### DIFF
--- a/go-app.js
+++ b/go-app.js
@@ -58,8 +58,8 @@ go.app = function() {
                 point: {
                     type: "Point",
                     coordinates: [
-                        contact.extra['location:geometry:location:lng'],
-                        contact.extra['location:geometry:location:lat']
+                        parseFloat(contact.extra['location:geometry:location:lng']),
+                        parseFloat(contact.extra['location:geometry:location:lat'])
                     ]
                 }
             };

--- a/src/app.js
+++ b/src/app.js
@@ -51,8 +51,8 @@ go.app = function() {
                 point: {
                     type: "Point",
                     coordinates: [
-                        contact.extra['location:geometry:location:lng'],
-                        contact.extra['location:geometry:location:lat']
+                        parseFloat(contact.extra['location:geometry:location:lng']),
+                        parseFloat(contact.extra['location:geometry:location:lat'])
                     ]
                 }
             };

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -16,7 +16,7 @@ module.exports = function() {
                "location": {
                   "point": {
                      "type": "Point",
-                     "coordinates": ["3.3", "3.33"]
+                     "coordinates": [3.3, 3.33]
                   }
                }
             }
@@ -37,7 +37,7 @@ module.exports = function() {
                   "id": 1,
                   "point": {
                      "type": "Point",
-                     "coordinates": ["3.3", "3.33"]
+                     "coordinates": [3.3, 3.33]
                   }
                }
             }
@@ -61,7 +61,7 @@ module.exports = function() {
                "location": {
                   "point": {
                      "type": "Point",
-                     "coordinates": ["3.1415", "2.7182"]
+                     "coordinates": [3.1415, 2.7182]
                   }
                }
             }
@@ -82,7 +82,7 @@ module.exports = function() {
                   "id": 2,
                   "point": {
                      "type": "Point",
-                     "coordinates": ["3.1415", "2.7182"]
+                     "coordinates": [3.1415, 2.7182]
                   }
                }
             }


### PR DESCRIPTION
wrap contact extras in `parseFloat()` before submission to API
