### PR TITLE
Remove unused "nearest" clinic type and clinic type config.

### DIFF
--- a/go-app.js
+++ b/go-app.js
@@ -51,14 +51,7 @@ go.app = function() {
         self.make_clinic_search_params = function() {
             var clinic_type_requested = self.im.user.answers.state_clinic_type;
             var search_data = {};
-
-            if (clinic_type_requested === "nearest") {
-                self.im.config.clinic_types.forEach(function(clinic_type) {
-                    search_data[clinic_type] = "true";
-                });
-            } else {
-                search_data[clinic_type_requested] = "true";
-            }
+            search_data[clinic_type_requested] = "true";
             return search_data;
         };
 

--- a/src/app.js
+++ b/src/app.js
@@ -44,14 +44,7 @@ go.app = function() {
         self.make_clinic_search_params = function() {
             var clinic_type_requested = self.im.user.answers.state_clinic_type;
             var search_data = {};
-
-            if (clinic_type_requested === "nearest") {
-                self.im.config.clinic_types.forEach(function(clinic_type) {
-                    search_data[clinic_type] = "true";
-                });
-            } else {
-                search_data[clinic_type_requested] = "true";
-            }
+            search_data[clinic_type_requested] = "true";
             return search_data;
         };
 

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -96,7 +96,6 @@ describe("app", function() {
                     lbs_providers: ['VODACOM', 'MTN'],
                     api_url: 'http://127.0.0.1:8000/clinicfinder/',
                     api_key: 'replace_with_token',
-                    clinic_types: ['mmc', 'hct'],
                     metric_store: 'usaid_clinicfinder_test',
                     template: "Your nearest clinics are: {{ results }}. " +
                               "Thanks for using Healthsites."


### PR DESCRIPTION
Currently these are unused and the `nearest` clinic type is not supported by the new AAT API, so keeping the unused support around could lead to surprising problems later.
