### PR TITLE
Add support for configuring the source of clinic data

### DIFF
--- a/go-app.js
+++ b/go-app.js
@@ -50,7 +50,11 @@ go.app = function() {
 
         self.make_clinic_search_params = function() {
             var clinic_type_requested = self.im.user.answers.state_clinic_type;
-            var search_data = {};
+            var clinic_data_source = (
+                self.im.config.clinic_data_source || "internal");
+            var search_data = {
+              source: clinic_data_source,
+            };
             search_data[clinic_type_requested] = "true";
             return search_data;
         };

--- a/go-app.js
+++ b/go-app.js
@@ -51,14 +51,7 @@ go.app = function() {
         self.make_clinic_search_params = function() {
             var clinic_type_requested = self.im.user.answers.state_clinic_type;
             var search_data = {};
-
-            if (clinic_type_requested === "nearest") {
-                self.im.config.clinic_types.forEach(function(clinic_type) {
-                    search_data[clinic_type] = "true";
-                });
-            } else {
-                search_data[clinic_type_requested] = "true";
-            }
+            search_data[clinic_type_requested] = "true";
             return search_data;
         };
 

--- a/src/app.js
+++ b/src/app.js
@@ -43,7 +43,11 @@ go.app = function() {
 
         self.make_clinic_search_params = function() {
             var clinic_type_requested = self.im.user.answers.state_clinic_type;
-            var search_data = {};
+            var clinic_data_source = (
+                self.im.config.clinic_data_source || "internal");
+            var search_data = {
+              source: clinic_data_source,
+            };
             search_data[clinic_type_requested] = "true";
             return search_data;
         };

--- a/src/app.js
+++ b/src/app.js
@@ -44,14 +44,7 @@ go.app = function() {
         self.make_clinic_search_params = function() {
             var clinic_type_requested = self.im.user.answers.state_clinic_type;
             var search_data = {};
-
-            if (clinic_type_requested === "nearest") {
-                self.im.config.clinic_types.forEach(function(clinic_type) {
-                    search_data[clinic_type] = "true";
-                });
-            } else {
-                search_data[clinic_type_requested] = "true";
-            }
+            search_data[clinic_type_requested] = "true";
             return search_data;
         };
 

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -305,6 +305,44 @@ describe("app", function() {
                             })
                             .run();
                     });
+
+                    describe("if a custom clinic source is configured",
+                    function () {
+                        it("should specify the clinic source in the search request",
+                        function() {
+                            return tester
+                                .setup.user.addr('082111')
+                                .setup.config.app({clinic_data_source: "aat"})
+                                .inputs(
+                                    {session_event: "new"},
+                                    { content: '1',
+                                      provider: 'MTN' },  // state_clinic_type
+                                    '1'  // state_locate_permission
+                                )
+                                .check.interaction({
+                                    state: 'state_health_services',
+                                    reply: [
+                                        "U will get an SMS with clinic info. " +
+                                        "Want 2 get more health info? T&Cs " +
+                                        "www.brothersforlife.mobi " +
+                                        "or www.zazi.org.za",
+                                        "1. Yes - I'm a Man",
+                                        "2. Yes - I'm a Woman",
+                                        "3. No"
+                                    ].join("\n")
+                                })
+                                .check(function (api) {
+                                    var search_request = api.http.requests[0];
+                                    assert.deepEqual(
+                                        search_request.data
+                                            .pointofinterest.search, {
+                                                "source": "aat",
+                                                "mmc": "true",
+                                            });
+                                })
+                                .run();
+                        });
+                    });
                 });
 
                 describe("if the user chooses 2. No don't locate", function() {
@@ -526,6 +564,42 @@ describe("app", function() {
                                 })
                                 .run();
                         });
+
+                    describe("if a custom clinic source is configured",
+                    function () {
+                        it("should specify the clinic source in the search request",
+                        function() {
+                            return tester
+                                .setup.user.addr('082111')
+                                .setup.config.app({clinic_data_source: "aat"})
+                                .inputs(
+                                    {session_event: "new"},
+                                    { content: '2',
+                                      provider: 'CellC' },  // state_clinic_type
+                                    'Friend Street'  // state_suburb
+                                )
+                                .check.interaction({
+                                    state: 'state_health_services',
+                                    reply: [
+                                        "U will get an SMS with clinic info. " +
+                                        "Want 2 get more health info? T&Cs " +
+                                        "www.brothersforlife.mobi " +
+                                        "or www.zazi.org.za",
+                                        "1. Yes - I'm a Man",
+                                        "2. Yes - I'm a Woman",
+                                        "3. No"
+                                    ].join("\n")
+                                })
+                                .check(function (api) {
+                                    var search_request = api.http.requests[1];
+                                    assert.deepEqual(search_request.data.search, {
+                                        "source": "aat",
+                                        "hct": "true",
+                                    });
+                                })
+                                .run();
+                        });
+                    });
 
                     describe("if there are multiple location options", function() {
                         it("should display a list of address options", function() {

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -96,7 +96,6 @@ describe("app", function() {
                     lbs_providers: ['VODACOM', 'MTN'],
                     api_url: 'http://127.0.0.1:8000/clinicfinder/',
                     api_key: 'replace_with_token',
-                    clinic_types: ['mmc', 'hct'],
                     metric_store: 'usaid_clinicfinder_test',
                     template: "Your nearest clinics are: {{ results }}. " +
                               "Thanks for using Healthsites."

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -149,6 +149,57 @@ module.exports = function() {
             "method": "POST",
             "url": "http://127.0.0.1:8000/clinicfinder/requestlookup/",
             "data": {
+                "search": {
+                    "hct": "true",
+                    "source": "aat"
+               },
+                "response": {
+                    "type": "SMS",
+                    "to_addr": "+082111",
+                    "template": "Your nearest clinics are: {{ results }}. Thanks for using Healthsites."
+                },
+                "location": {
+                    "point": {
+                        "type": "Point",
+                        "coordinates": [
+                            3.1415,
+                            2.7182
+                        ]
+                    }
+                }
+            }
+         },
+         "response": {
+            "data": {
+               "id": 2,
+               "url": "http://127.0.0.1:8000/clinicfinder/requestlookup/2/",
+               "search": {
+                  "hct": "true",
+                  "source": "aat"
+               },
+               "response": {
+                  "type": "SMS",
+                  "to_addr": "+082111",
+                  "template": "Your nearest clinics are: {{ results }}. Thanks for using Healthsites."
+               },
+               "location": {
+                  "id": 2,
+                  "point": {
+                     "type": "Point",
+                     "coordinates": [3.1415, 2.7182]
+                  }
+               }
+            }
+         }
+      },
+
+
+
+      {
+         "request": {
+            "method": "POST",
+            "url": "http://127.0.0.1:8000/clinicfinder/requestlookup/",
+            "data": {
                "search": {
                   "mmc": "true",
                   "source": "internal"
@@ -225,6 +276,54 @@ module.exports = function() {
                   "search": {
                      "mmc": "true",
                      "source": "internal"
+                  },
+                  "response": {
+                     "type": "SMS",
+                     "to_addr": "+082111",
+                     "template": "Your nearest clinics are: {{ results }}. Thanks for using Healthsites."
+                  },
+                  "location": null
+               }
+            }
+         }
+      },
+
+
+
+      {
+         "request": {
+            "method": "POST",
+            "url": "http://127.0.0.1:8000/clinicfinder/lbsrequest/",
+            "data": {
+               "search": {
+                  "msisdn": "082111"
+               },
+               "pointofinterest": {
+                  "search": {
+                     "mmc": "true",
+                     "source": "aat"
+                  },
+                  "response": {
+                     "type": "SMS",
+                     "to_addr": "+082111",
+                     "template": "Your nearest clinics are: {{ results }}. Thanks for using Healthsites."
+                  },
+                  "location": null
+               }
+            }
+         },
+         "response": {
+            "data": {
+               "id": 1,
+               "url": "http://127.0.0.1:8000/clinicfinder/lbsrequest/1/",
+               "search": {
+                  "msisdn": "082111"
+               },
+               "pointofinterest": {
+                  "id": 3,
+                  "search": {
+                     "mmc": "true",
+                     "source": "aat"
                   },
                   "response": {
                      "type": "SMS",

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -6,7 +6,8 @@ module.exports = function() {
             "url": "http://127.0.0.1:8000/clinicfinder/requestlookup/",
             "data": {
                "search": {
-                  "mmc": "true"
+                  "mmc": "true",
+                  "source": "internal"
                },
                "response": {
                   "type": "SMS",
@@ -26,7 +27,8 @@ module.exports = function() {
                "id": 1,
                "url": "http://127.0.0.1:8000/clinicfinder/requestlookup/1/",
                "search": {
-                  "mmc": "true"
+                  "mmc": "true",
+                  "source": "internal"
                },
                "response": {
                   "type": "SMS",
@@ -51,7 +53,8 @@ module.exports = function() {
             "url": "http://127.0.0.1:8000/clinicfinder/requestlookup/",
             "data": {
                "search": {
-                  "mmc": "true"
+                  "mmc": "true",
+                  "source": "internal"
                },
                "response": {
                   "type": "SMS",
@@ -71,7 +74,8 @@ module.exports = function() {
                "id": 2,
                "url": "http://127.0.0.1:8000/clinicfinder/requestlookup/2/",
                "search": {
-                  "mmc": "true"
+                  "mmc": "true",
+                  "source": "internal"
                },
                "response": {
                   "type": "SMS",
@@ -95,7 +99,8 @@ module.exports = function() {
             "url": "http://127.0.0.1:8000/clinicfinder/requestlookup/",
             "data": {
                 "search": {
-                    "hct": "true"
+                    "hct": "true",
+                    "source": "internal"
                },
                 "response": {
                     "type": "SMS",
@@ -118,7 +123,8 @@ module.exports = function() {
                "id": 2,
                "url": "http://127.0.0.1:8000/clinicfinder/requestlookup/2/",
                "search": {
-                  "hct": "true"
+                  "hct": "true",
+                  "source": "internal"
                },
                "response": {
                   "type": "SMS",
@@ -144,7 +150,8 @@ module.exports = function() {
             "url": "http://127.0.0.1:8000/clinicfinder/requestlookup/",
             "data": {
                "search": {
-                  "mmc": "true"
+                  "mmc": "true",
+                  "source": "internal"
                },
                "response": {
                   "template_type": "SMS",
@@ -164,7 +171,8 @@ module.exports = function() {
                "id": 2,
                "url": "http://127.0.0.1:8000/clinicfinder/requestlookup/2/",
                "search": {
-                  "mmc": "true"
+                  "mmc": "true",
+                  "source": "internal"
                },
                "response": {
                   "template_type": "SMS",
@@ -193,7 +201,8 @@ module.exports = function() {
                },
                "pointofinterest": {
                   "search": {
-                     "mmc": "true"
+                     "mmc": "true",
+                     "source": "internal"
                   },
                   "response": {
                      "type": "SMS",
@@ -214,7 +223,8 @@ module.exports = function() {
                "pointofinterest": {
                   "id": 3,
                   "search": {
-                     "mmc": "true"
+                     "mmc": "true",
+                     "source": "internal"
                   },
                   "response": {
                      "type": "SMS",


### PR DESCRIPTION
We need to add support for using AAT's API as a source of clinic location data. Support has already been added to the Django backend. The jsbox API requests just need to be updated to specify the source in the search data as follows:

``` javascript
{
    search: {
        mmc: "true",
        source: "aat"
    }
}
```

If `source` is `null`, absent or `internal`, the default Django backend clinic location data is used as the source.
